### PR TITLE
Update Labyrinth Runner dip defaults to reflect documented defaults

### DIFF
--- a/rom/mra/Trick Trap (World).mra
+++ b/rom/mra/Trick Trap (World).mra
@@ -52,7 +52,7 @@
     <rom index="1">
         <part>01</part>
     </rom>
-    <switches base="8" default="FF,FF,FF">
+    <switches base="8" default="FF,5A,F7">
         <!-- DSW1 -->
         <dip name="Coin A" bits="0,3" ids="Free Play,4/3,4/1,3/4,3/2,3/1,2/5,2/3,2/1,1/7,1/6,1/5,1/4,1/3,1/2,1/1"/>
         <dip name="Coin B" bits="4,7" ids="None,4/3,4/1,3/4,3/2,3/1,2/5,2/3,2/1,1/7,1/6,1/5,1/4,1/3,1/2,1/1"/>

--- a/rom/mra/_alt/_Labyrinth Runner/Labyrinth Runner (Japan).mra
+++ b/rom/mra/_alt/_Labyrinth Runner/Labyrinth Runner (Japan).mra
@@ -47,7 +47,7 @@
     <rom index="1">
         <part>01</part>
     </rom>
-    <switches base="8" default="FF,FF,FF">
+    <switches base="8" default="FF,5A,F7">
         <!-- DSW1 -->
         <dip name="Coin A" bits="0,3" ids="Free Play,4/3,4/1,3/4,3/2,3/1,2/5,2/3,2/1,1/7,1/6,1/5,1/4,1/3,1/2,1/1"/>
         <dip name="Coin B" bits="4,7" ids="None,4/3,4/1,3/4,3/2,3/1,2/5,2/3,2/1,1/7,1/6,1/5,1/4,1/3,1/2,1/1"/>

--- a/rom/mra/_alt/_Labyrinth Runner/Labyrinth Runner (World Ver. K).mra
+++ b/rom/mra/_alt/_Labyrinth Runner/Labyrinth Runner (World Ver. K).mra
@@ -52,7 +52,7 @@
     <rom index="1">
         <part>01</part>
     </rom>
-    <switches base="8" default="FF,FF,FF">
+    <switches base="8" default="FF,5A,F7">
         <!-- DSW1 -->
         <dip name="Coin A" bits="0,3" ids="Free Play,4/3,4/1,3/4,3/2,3/1,2/5,2/3,2/1,1/7,1/6,1/5,1/4,1/3,1/2,1/1"/>
         <dip name="Coin B" bits="4,7" ids="None,4/3,4/1,3/4,3/2,3/1,2/5,2/3,2/1,1/7,1/6,1/5,1/4,1/3,1/2,1/1"/>


### PR DESCRIPTION
See manual here: https://archive.org/details/arcademanual_Labyrinth_Runner/page/n3/mode/2up

